### PR TITLE
ci: add multi-arch (linux/amd64 + linux/arm64) GHCR build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build and push (linux/amd64, linux/arm64)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build multi-arch image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push (linux/amd64, linux/arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -76,7 +76,23 @@ Versions prior to 29.0 were using BDB wallet, system will automaticly update you
    docker build -t bitcoin-signet .
    ```
 
-2. **Running the Docker Image**:
+   Multi-arch (`linux/amd64` + `linux/arm64`) build via buildx:
+
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 -t bitcoin-signet .
+   ```
+
+   The `Dockerfile` selects the matching `bitcoind` binary tarball from bitcoincore.org based on `TARGETPLATFORM`, so both architectures build from the same source without changes.
+
+2. **Pre-built Image**:
+
+   Multi-arch images are published to GHCR on every push to `main` and on every `v*` tag:
+
+   ```bash
+   docker pull ghcr.io/alpenlabs/bitcoin_signet:latest
+   ```
+
+3. **Running the Docker Image**:
    ```bash
    docker run -d --name bitcoin-signet-instance bitcoin-signet
    ```


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds and publishes a multi-arch image manifest (`linux/amd64` + `linux/arm64`) to GHCR.

The existing `Dockerfile` already has a `TARGETPLATFORM` switch that selects the correct `bitcoind` tarball (`x86_64-linux-gnu` vs `aarch64-linux-gnu`) from bitcoincore.org, so no Dockerfile changes are needed.

## Why

Apple Silicon / ARM64 hosts that run a signet node (e.g. as a Bitcoin DA layer for an L2 testnet) currently have to fall back to amd64 emulation because no arm64 manifest is published. With multi-arch publishing they get a native build out of the box.

## What it does

| Trigger | Tags published |
|---|---|
| push to `main` | `ghcr.io/alpenlabs/bitcoin_signet:main`, `:latest`, `:sha-<short>` |
| push of a `v*` tag | `ghcr.io/alpenlabs/bitcoin_signet:<tag>`, `:sha-<short>` |
| manual `workflow_dispatch` | `:sha-<short>` |

Plus `provenance: mode=max` and `sbom: true` for supply-chain attestation.

## Required secrets / permissions

None. Uses the built-in `GITHUB_TOKEN` to push to GHCR.

## Test plan

- [ ] Manual `workflow_dispatch` produces a multi-arch GHCR image
- [ ] `docker manifest inspect ghcr.io/alpenlabs/bitcoin_signet:<tag>` lists both `amd64` and `arm64` entries
- [ ] Pulling on an `arm64` host retrieves the native arm64 image (no QEMU)

## Notes

- Branch is based directly on `alpenlabs/main` — clean two-dot diff: 1 commit, 2 files
- README updated with the multi-arch buildx command and the GHCR pull URL
- arm64 build runs via QEMU on the standard `ubuntu-latest` runner; if you'd rather use `ubuntu-24.04-arm` for a native arm64 leg via a build matrix, happy to refactor