### PR TITLE
ci: add ECR Public image build/push workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,135 @@
+# Builds the custom-signet bitcoind image and pushes to ECR Public on
+# merge to main (or manual dispatch).
+#
+# Pushes to: public.ecr.aws/alpenlabs/signet
+# Tag scheme:
+#   - sha-<short>  for every main push
+#   - latest       on main pushes
+#   - <custom>     when triggered via workflow_dispatch with `tag` input
+
+name: CI — Build and Push Signet Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+      - "*.sh"
+      - "miner"
+      - "miner_imports/**"
+      - "*.py"
+      - ".github/workflows/ci-build.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Custom tag to push (default: sha-<short>)"
+        required: false
+        type: string
+
+env:
+  AWS_REGION: us-east-1
+  ECR_PUBLIC_REGISTRY: public.ecr.aws/alpenlabs
+  IMAGE_NAME: signet
+
+# Cancel in-progress runs for the same ref (except main)
+concurrency:
+  group: ci-build-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-and-push:
+    name: Build and push signet image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for OIDC
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        with:
+          persist-credentials: false
+
+      - name: Resolve image tag
+        id: resolve
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          INPUT_TAG="${{ inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            FINAL_TAG="$INPUT_TAG"
+          else
+            FINAL_TAG="sha-${SHORT_SHA}"
+          fi
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "tag=${FINAL_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: ${FINAL_TAG} (commit ${SHORT_SHA})"
+
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4
+        with:
+          role-to-assume: arn:aws:iam::496607027995:role/github-actions-ecr-push
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR Public
+        run: |
+          aws ecr-public get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin public.ecr.aws
+
+      - name: Build and push multi-arch image
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHORT_SHA: ${{ steps.resolve.outputs.short_sha }}
+        run: |
+          FULL_IMAGE="${{ env.ECR_PUBLIC_REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}"
+
+          # Build extra tag args:
+          #   - sha-<short>: always (for traceability)
+          #   - latest: only on main push
+          EXTRA_TAGS=()
+          if [ "${TAG}" != "sha-${SHORT_SHA}" ]; then
+            EXTRA_TAGS+=( -t "${{ env.ECR_PUBLIC_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHORT_SHA}" )
+          fi
+          if [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ github.event_name }}" = "push" ]; then
+            EXTRA_TAGS+=( -t "${{ env.ECR_PUBLIC_REGISTRY }}/${{ env.IMAGE_NAME }}:latest" )
+          fi
+
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --label "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --push \
+            -t "${FULL_IMAGE}" \
+            "${EXTRA_TAGS[@]}" \
+            -f Dockerfile .
+
+          echo "Pushed: ${FULL_IMAGE}"
+          for t in "${EXTRA_TAGS[@]}"; do
+            [ "$t" != "-t" ] && echo "Pushed: $t"
+          done
+
+      - name: Build summary
+        if: always()
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SHORT_SHA: ${{ steps.resolve.outputs.short_sha }}
+        run: |
+          {
+            echo "## Signet Image Build"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| **Commit** | \`${{ github.sha }}\` |"
+            echo "| **Short SHA** | \`${SHORT_SHA}\` |"
+            echo "| **Pushed Tag** | \`${TAG}\` |"
+            echo "| **Ref** | \`${{ github.ref_name }}\` |"
+            echo "| **Event** | \`${{ github.event_name }}\` |"
+            echo "| **Image** | \`${{ env.ECR_PUBLIC_REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}\` |"
+            echo "| **Platforms** | linux/amd64, linux/arm64 |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,7 +73,12 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4
         with:
-          role-to-assume: arn:aws:iam::496607027995:role/github-actions-ecr-push
+          # Dedicated least-privilege role: trust scoped to this repo's
+          # main branch only, push permission limited to the `signet`
+          # ECR Public repo only (cannot push to any other repo).
+          # Role defined in alpenlabs/alpen-infra:
+          #   aws/shared-services/us-east-1/shared/iam/github-actions-signet-push/
+          role-to-assume: arn:aws:iam::496607027995:role/github-actions-signet-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR Public


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci-build.yml` to build the custom-signet bitcoind image and push to ECR Public on merge to `main` or via workflow_dispatch. Replaces the previous manual build → push workflow (where image tags like `tmpconf2` were produced ad-hoc locally and pushed by hand).

## What it does

- **Triggers:**
  - Push to `main` when relevant files change (`Dockerfile`, `*.sh`, `miner`, `miner_imports/**`, `*.py`, the workflow itself)
  - Manual `workflow_dispatch` with optional custom tag input
- **Build:** multi-arch (`linux/amd64` + `linux/arm64`) via Docker Buildx + QEMU, matching the Dockerfile's existing `TARGETPLATFORM` cross-compile pattern
- **Push:** `public.ecr.aws/alpenlabs/signet:<tag>`
- **Tags:**
  - `sha-<short>` on every build (traceability — every commit pinable in deployments)
  - `latest` on main-branch pushes
  - Custom tag via workflow_dispatch input (e.g., `tmpconf3` for one-off ops tags)
- **OIDC:** assumes `arn:aws:iam::496607027995:role/github-actions-ecr-push` in the shared-services account — no long-lived AWS keys

## Security model

- All third-party actions pinned to full commit SHA (matches `alpen` repo's zizmor lint pattern)
- Workflow only triggers on `main` (push) or manual dispatch — no fork-PR build/push
- OIDC trust is scoped to `refs/heads/main` only in the IAM role (separate companion PR)


## Test plan

- [x] Workflow YAML lints clean (no syntax issues)
- [x] All actions pinned to commit SHAs (zizmor-friendly)
- [ ] After merging both PRs: trigger workflow_dispatch manually with a custom tag (e.g., `test-1`) and verify image lands at `public.ecr.aws/alpenlabs/signet:test-1`
- [ ] Confirm multi-arch manifest: `docker buildx imagetools inspect public.ecr.aws/alpenlabs/signet:test-1` should show both `linux/amd64` and `linux/arm64`
- [ ] After validation, trigger a real push to main and verify `:sha-<short>` + `:latest` both appear

## Future enhancements (out of scope)

- Add a `lint` job: `hadolint` on `Dockerfile`, `shellcheck` on `*.sh`
- ECR lifecycle policy: keep last 30 images, expire untagged after 7d (lives in `alpen-infra/aws/shared-services/.../ecr/`)
- A `release` workflow that pushes semver-tagged immutable releases when a git tag is pushed
